### PR TITLE
add 2 option for linux node group ami

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,9 @@ the details of the custom_node_groups variable
 | `disable_windows_defender` | `bool` | (Optional, Default = `false`) Whether to disable Windows Defender on the nodes in the node group. |
 | `taints` | `list(object({key = string, value = string, effect = string}))` | A list of taints to apply to the nodes in the node group. Each taint is an object with `key`, `value`, and `effect` attributes. |
 | `labels` | `map(string)` | A map of labels to apply to the nodes in the node group. Each label is a key-value pair. |
-|`windows_ami_type`| `string` | (Optional, Default =  `null`) AMI type for for each custom Windows node group |
-| `lin_ami_type` | `string` | (Optional, Default =  `null`) AMI type for for each custom Linux node group |
+|`windows_ami_type`| `string` | Specify the Windows version, for your EKS Windows node group (Default = `WINDOWS_CORE_2019_x86_64`) |
+| `lin_ami_type` | `string` | Specify the Linux AMI type for your EKS Linux node group (Default = `AL2023_x86_64_STANDARD`) |
+
 
 # The Changes:
   - [Upgrade to 3.x.x](https://github.com/aws-terraform-module/terraform-aws-eks-windows/blob/master/docs/UPGRADE-3.0.md)

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ the details of the custom_node_groups variable
 | `taints` | `list(object({key = string, value = string, effect = string}))` | A list of taints to apply to the nodes in the node group. Each taint is an object with `key`, `value`, and `effect` attributes. |
 | `labels` | `map(string)` | A map of labels to apply to the nodes in the node group. Each label is a key-value pair. |
 |`windows_ami_type`| `string` | (Optional, Default =  `null`) AMI type for for each custom Windows node group |
-| `linux_ami_type` | `string` | (Optional, Default =  `null`) AMI type for for each custom Linux node group |
+| `lin_ami_type` | `string` | (Optional, Default =  `null`) AMI type for for each custom Linux node group |
 
 
 # The Changes:

--- a/README.md
+++ b/README.md
@@ -238,9 +238,11 @@ the details of the custom_node_groups variable
 |`windows_ami_type`| `string` | (Optional, Default =  `null`) AMI type for for each custom Windows node group |
 | `lin_ami_type` | `string` | (Optional, Default =  `null`) AMI type for for each custom Linux node group |
 
-
 # The Changes:
   - [Upgrade to 3.x.x](https://github.com/aws-terraform-module/terraform-aws-eks-windows/blob/master/docs/UPGRADE-3.0.md)
 
 # Issue Reference:
   - https://github.com/aws-terraform-module/terraform-aws-eks-windows/blob/master/docs/Issue.md
+
+# AMI Reference:
+  - https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_eks/NodegroupAmiType.html

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ the details of the custom_node_groups variable
 | `taints` | `list(object({key = string, value = string, effect = string}))` | A list of taints to apply to the nodes in the node group. Each taint is an object with `key`, `value`, and `effect` attributes. |
 | `labels` | `map(string)` | A map of labels to apply to the nodes in the node group. Each label is a key-value pair. |
 |`windows_ami_type`| `string` | (Optional, Default =  `null`) AMI type for for each custom Windows node group |
+| `linux_ami_type` | `string` | (Optional, Default =  `null`) AMI type for for each custom Linux node group |
+
 
 # The Changes:
   - [Upgrade to 3.x.x](https://github.com/aws-terraform-module/terraform-aws-eks-windows/blob/master/docs/UPGRADE-3.0.md)

--- a/c2-01-local-values.tf
+++ b/c2-01-local-values.tf
@@ -2,11 +2,4 @@
 # locals {
 #   effective_win_subnet_ids = length(var.extra_subnet_ids) > 0 ? var.extra_subnet_ids : var.private_subnet_ids
 # }
-locals {
-  linux_ami_type_map = {
-    "amazon-linux-2023" = "AL2023_x86_64"
-    "bottlerocket"      = "BOTTLEROCKET_x86_64"
-  }
 
-  linux_ami_type = local.linux_ami_type_map[var.lin_ami_type]
-}

--- a/c2-01-local-values.tf
+++ b/c2-01-local-values.tf
@@ -8,5 +8,5 @@ locals {
     "bottlerocket"      = "BOTTLEROCKET_x86_64"
   }
 
-  linux_ami_type = local.linux_ami_type_map[var.linux_ami_type]
+  linux_ami_type = local.linux_ami_type_map[var.lin_ami_type]
 }

--- a/c2-01-local-values.tf
+++ b/c2-01-local-values.tf
@@ -2,3 +2,11 @@
 # locals {
 #   effective_win_subnet_ids = length(var.extra_subnet_ids) > 0 ? var.extra_subnet_ids : var.private_subnet_ids
 # }
+locals {
+  linux_ami_type_map = {
+    "amazon-linux-2023" = "AL2023_x86_64"
+    "bottlerocket"      = "BOTTLEROCKET_x86_64"
+  }
+
+  linux_ami_type = local.linux_ami_type_map[var.linux_ami_type]
+}

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -57,14 +57,9 @@ variable "lin_max_size" {
 }
 
 variable "lin_ami_type" {
-  description = "AMI type for the Linux Nodes. Must be one of: 'amazon-linux-2023', 'bottlerocket'."
+  description = "AMI type for the Linux Nodes."
   type        = string
-  default     = "amazon-linux-2023"
-
-  validation {
-    condition     = contains(["amazon-linux-2023", "bottlerocket"], var.linux_ami_type)
-    error_message = "Now supported Linux AMI types are 'amazon-linux-2023' and 'bottlerocket'. Please choose one of these."
-  }
+  default     = "AL2023_x86_64_STANDARD"
 }
 
 # # eks autoscaling for windows

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -56,8 +56,7 @@ variable "lin_max_size" {
   type        = number
 }
 
-# eks linux node group
-variable "linux_ami_type" {
+variable "lin_ami_type" {
   description = "AMI type for the Linux Nodes. Must be one of: 'amazon-linux-2023', 'bottlerocket'."
   type        = string
   default     = "amazon-linux-2023"

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -56,6 +56,17 @@ variable "lin_max_size" {
   type        = number
 }
 
+# eks linux node group
+variable "linux_ami_type" {
+  description = "AMI type for the Linux Nodes. Must be one of: 'amazon-linux-2023', 'bottlerocket'."
+  type        = string
+  default     = "amazon-linux-2023"
+
+  validation {
+    condition     = contains(["amazon-linux-2023", "bottlerocket"], var.linux_ami_type)
+    error_message = "Now supported Linux AMI types are 'amazon-linux-2023' and 'bottlerocket'. Please choose one of these."
+  }
+}
 
 # # eks autoscaling for windows
 variable "win_min_size" {

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -46,6 +46,7 @@ module "eks" {
           "k8s.io/cluster-autoscaler/${var.eks_cluster_name}" = "owned"
         }
 
+        ami_types      = local.linux_ami_type
         instance_types = [var.lin_instance_type]
         min_size       = var.lin_min_size
         max_size       = var.lin_max_size

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -46,7 +46,7 @@ module "eks" {
           "k8s.io/cluster-autoscaler/${var.eks_cluster_name}" = "owned"
         }
 
-        ami_type       = local.linux_ami_type
+        ami_type       = var.lin_ami_type
         instance_types = [var.lin_instance_type]
         min_size       = var.lin_min_size
         max_size       = var.lin_max_size

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -46,7 +46,7 @@ module "eks" {
           "k8s.io/cluster-autoscaler/${var.eks_cluster_name}" = "owned"
         }
 
-        ami_types      = local.linux_ami_type
+        ami_type       = local.linux_ami_type
         instance_types = [var.lin_instance_type]
         min_size       = var.lin_min_size
         max_size       = var.lin_max_size


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying the AMI type for Linux node groups, allowing selection between "amazon-linux-2023" and "bottlerocket".
- **Documentation**
  - Updated documentation to describe the new `lin_ami_type` attribute for custom node groups, including its default value and usage.
  - Added an "AMI Reference" section linking to AWS CDK documentation for EKS Nodegroup AMI types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->