### PR TITLE
Feature/enable spot instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# terraform-aws-eks-windows
+# terraform-aws-eks-windows Hello
 
 The eks windows module is based on the eks module v20.x.x
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ output "out_private_subnets" {
   value = data.terraform_remote_state.network.outputs.private_subnets
 }
 
-# ⚠️ Breaking Change Notice: Starting from version 4.0.0, instance type variables now expect lists
+# ⚠️ Breaking Change Notice: Starting from version 3.7.0, instance type variables now expect lists
 # - lin_instance_type = ["t3.medium"] (instead of "t3.medium")
 # - win_instance_type = ["t3.xlarge"] (instead of "t3.xlarge")
 
@@ -173,7 +173,7 @@ output "oidc_provider_arn" {
 > You can use the **custom\_node\_groups** variable to define your desired node Groups.  
 > we are enhance at: [Create the dynamic extra node group #41](https://github.com/aws-terraform-module/terraform-aws-eks-windows/issues/41)
 
-> **⚠️ Breaking Change Notice**: Starting from version 4.0.0, the following variables now expect lists of strings instead of single strings to enable support for multiple instance types for better availability:
+> **⚠️ Breaking Change Notice**: Starting from version 3.7.0, the following variables now expect lists of strings instead of single strings to enable support for multiple instance types for better availability:
 > - `lin_instance_type` (e.g., `["t3.medium"]` instead of `"t3.medium"`)
 > - `win_instance_type` (e.g., `["t3.xlarge"]` instead of `"t3.xlarge"`)
 > - `instance_type` in `custom_node_groups` (e.g., `["t3.large"]` instead of `"t3.large"`)
@@ -181,7 +181,7 @@ output "oidc_provider_arn" {
 #### example:
 
 ```hcl
-# ⚠️ Breaking Change Notice: Starting from version 4.0.0, instance type variables now expect lists
+# ⚠️ Breaking Change Notice: Starting from version 3.7.0, instance type variables now expect lists
 # - lin_instance_type = ["m5.2xlarge"] (instead of "m5.2xlarge")
 # - win_instance_type = ["t3.xlarge"] (instead of "t3.xlarge")
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ output "out_private_subnets" {
   value = data.terraform_remote_state.network.outputs.private_subnets
 }
 
+# ⚠️ Breaking Change Notice: Starting from version 4.0.0, instance type variables now expect lists
+# - lin_instance_type = ["t3.medium"] (instead of "t3.medium")
+# - win_instance_type = ["t3.xlarge"] (instead of "t3.xlarge")
+
 module "eks-windows" {
     source  = "aws-terraform-module/eks-windows/aws"
     version = "2.5.1"
@@ -117,11 +121,11 @@ module "eks-windows" {
     lin_desired_size = 2
     lin_max_size = 2
     lin_min_size = 2
-    lin_instance_type = "t3.medium"
+    lin_instance_type = ["t3.medium"]
     win_desired_size = 2
     win_max_size = 2
     win_min_size = 2
-    win_instance_type = "t3.xlarge"
+    win_instance_type = ["t3.xlarge"]
     node_host_key_name = "eks-terraform-key"
     
     # Example configuration for CoreDNS auto-scaling
@@ -169,9 +173,18 @@ output "oidc_provider_arn" {
 > You can use the **custom\_node\_groups** variable to define your desired node Groups.  
 > we are enhance at: [Create the dynamic extra node group #41](https://github.com/aws-terraform-module/terraform-aws-eks-windows/issues/41)
 
+> **⚠️ Breaking Change Notice**: Starting from version 4.0.0, the following variables now expect lists of strings instead of single strings to enable support for multiple instance types for better availability:
+> - `lin_instance_type` (e.g., `["t3.medium"]` instead of `"t3.medium"`)
+> - `win_instance_type` (e.g., `["t3.xlarge"]` instead of `"t3.xlarge"`)
+> - `instance_type` in `custom_node_groups` (e.g., `["t3.large"]` instead of `"t3.large"`)
+
 #### example:
 
 ```hcl
+# ⚠️ Breaking Change Notice: Starting from version 4.0.0, instance type variables now expect lists
+# - lin_instance_type = ["m5.2xlarge"] (instead of "m5.2xlarge")
+# - win_instance_type = ["t3.xlarge"] (instead of "t3.xlarge")
+
 module "eks-windows" {
     source  = "aws-terraform-module/eks-windows/aws"
     version = "3.x.x"
@@ -184,11 +197,11 @@ module "eks-windows" {
     lin_desired_size = 2
     lin_max_size = 2
     lin_min_size = 2
-    lin_instance_type = "m5.2xlarge"
+    lin_instance_type = ["m5.2xlarge"]
     win_desired_size = 2
     win_max_size = 2
     win_min_size = 1
-    win_instance_type = "t3.xlarge"
+    win_instance_type = ["t3.xlarge"]
     disable_windows_defender = true
     node_host_key_name = "eks-terraform-key"
 
@@ -198,7 +211,7 @@ module "eks-windows" {
       {
         name         = "windows-group"
         platform     = "windows"
-        instance_type= "t3.large"
+        instance_type= ["t3.large"]
         subnet_ids   = ["subnet-04bdeb40bc6cfdc4c", "subnet-04bdeb40bc6cfdc4c"]
         min_size     = 1
         max_size     = 3
@@ -217,6 +230,25 @@ module "eks-windows" {
       }
     ]
 
+    # Example with multiple instance types for better availability
+    # custom_node_groups = [
+    #   {
+    #     name         = "linux-mixed"
+    #     platform     = "linux"
+    #     instance_type= ["m5.large", "m5.xlarge", "m6i.large"]
+    #     subnet_ids   = ["subnet-04bdeb40bc6cfdc4c", "subnet-04bdeb40bc6cfdc4c"]
+    #     min_size     = 1
+    #     max_size     = 3
+    #     desired_size = 2
+    #     taints      = []
+    #     labels      = {}
+    #   }
+    # ]
+
+# You can also use multiple instance types for main node groups:
+# lin_instance_type = ["m5.large", "m5.xlarge", "m6i.large"]
+# win_instance_type = ["t3.xlarge", "t3.2xlarge"]
+
 }
 ```
 
@@ -227,7 +259,7 @@ the details of the custom_node_groups variable
 | --- | --- | --- |
 | `name` | `string` | The name of the node group. |
 | `platform` | `string` | The platform of the nodes in the node group (e.g., Linux, Windows). |
-| `instance_type` | `string` | The type of instance to use for the nodes in the node group. |
+| `instance_type` | `list(string)` | The type of instance to use for the nodes in the node group. |
 | `desired_size` | `number` | The desired number of nodes in the node group. |
 | `subnet_ids` | `list(string)` | (Optional)The individual subnet IDs for the node group.. |
 | `max_size` | `number` | The maximum number of nodes in the node group. |

--- a/README.md
+++ b/README.md
@@ -105,9 +105,7 @@ output "out_private_subnets" {
   value = data.terraform_remote_state.network.outputs.private_subnets
 }
 
-# ⚠️ Breaking Change Notice: Starting from version 3.7.0, instance type variables now expect lists
-# - lin_instance_type = ["t3.medium"] (instead of "t3.medium")
-# - win_instance_type = ["t3.xlarge"] (instead of "t3.xlarge")
+
 
 module "eks-windows" {
     source  = "aws-terraform-module/eks-windows/aws"
@@ -173,18 +171,11 @@ output "oidc_provider_arn" {
 > You can use the **custom\_node\_groups** variable to define your desired node Groups.  
 > we are enhance at: [Create the dynamic extra node group #41](https://github.com/aws-terraform-module/terraform-aws-eks-windows/issues/41)
 
-> **⚠️ Breaking Change Notice**: Starting from version 3.7.0, the following variables now expect lists of strings instead of single strings to enable support for multiple instance types for better availability:
-> - `lin_instance_type` (e.g., `["t3.medium"]` instead of `"t3.medium"`)
-> - `win_instance_type` (e.g., `["t3.xlarge"]` instead of `"t3.xlarge"`)
-> - `instance_type` in `custom_node_groups` (e.g., `["t3.large"]` instead of `"t3.large"`)
+
 
 #### example:
 
 ```hcl
-# ⚠️ Breaking Change Notice: Starting from version 3.7.0, instance type variables now expect lists
-# - lin_instance_type = ["m5.2xlarge"] (instead of "m5.2xlarge")
-# - win_instance_type = ["t3.xlarge"] (instead of "t3.xlarge")
-
 module "eks-windows" {
     source  = "aws-terraform-module/eks-windows/aws"
     version = "3.x.x"
@@ -273,6 +264,8 @@ the details of the custom_node_groups variable
 
 # The Changes:
   - [Upgrade to 3.x.x](https://github.com/aws-terraform-module/terraform-aws-eks-windows/blob/master/docs/UPGRADE-3.0.md)
+
+  - [Upgrade from 3.x.x to 3.7.x](https://github.com/aws-terraform-module/terraform-aws-eks-windows/blob/master/docs/UPGRADE-3.7.0.md)
 
 # Issue Reference:
   - https://github.com/aws-terraform-module/terraform-aws-eks-windows/blob/master/docs/Issue.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# terraform-aws-eks-windows Hello
+# terraform-aws-eks-windows
 
 The eks windows module is based on the eks module v20.x.x
 

--- a/c2-01-local-values.tf
+++ b/c2-01-local-values.tf
@@ -3,3 +3,16 @@
 #   effective_win_subnet_ids = length(var.extra_subnet_ids) > 0 ? var.extra_subnet_ids : var.private_subnet_ids
 # }
 
+
+## Local Values for EKS
+locals {
+  # Determine instance types, prioritizing the list variable over the single string variable
+  linux_instance_types   = length(var.lin_instance_type_list) > 0 ? var.lin_instance_type_list : [var.lin_instance_type]
+  windows_instance_types = length(var.win_instance_type_list) > 0 ? var.win_instance_type_list : [var.win_instance_type]
+
+  # Create a map of instance types for each custom node group to improve readability.
+  # This logic prioritizes the '_list' variable, falling back to the string variable for backward compatibility.
+  custom_node_group_instance_types = {
+    for ng in var.custom_node_groups : ng.name => length(ng.instance_type_list) > 0 ? ng.instance_type_list : (ng.instance_type != null ? [ng.instance_type] : [])
+  }
+}

--- a/c2-01-local-values.tf
+++ b/c2-01-local-values.tf
@@ -7,12 +7,6 @@
 ## Local Values for EKS
 locals {
   # Determine instance types, prioritizing the list variable over the single string variable
-  linux_instance_types   = length(var.lin_instance_type_list) > 0 ? var.lin_instance_type_list : [var.lin_instance_type]
-  windows_instance_types = length(var.win_instance_type_list) > 0 ? var.win_instance_type_list : [var.win_instance_type]
-
-  # Create a map of instance types for each custom node group to improve readability.
-  # This logic prioritizes the '_list' variable, falling back to the string variable for backward compatibility.
-  custom_node_group_instance_types = {
-    for ng in var.custom_node_groups : ng.name => length(ng.instance_type_list) > 0 ? ng.instance_type_list : (ng.instance_type != null ? [ng.instance_type] : [])
-  }
+  linux_instance_types   = length(coalesce(var.lin_instance_type_list, [])) > 0 ? coalesce(var.lin_instance_type_list, []) : (var.lin_instance_type != null ? [var.lin_instance_type] : [])
+  windows_instance_types = length(coalesce(var.win_instance_type_list, [])) > 0 ? coalesce(var.win_instance_type_list, []) : (var.win_instance_type != null ? [var.win_instance_type] : [])
 }

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -228,7 +228,7 @@ variable "custom_node_groups" {
         && alltrue([for t in ng.instance_type_list : length(trim(t)) > 0])
       )
     ])
-    error_message = "Each custom_node_groups element must set either non-empty instance_type or instance_type_list; capacity_type must be ON_DEMAND or SPOT; lists cannot contain empty strings; if a list is set, instance_type must be unset."
+    error_message = "Each custom_node_groups element must set either non-empty instance_type or instance_type_list; capacity_type must be ON_DEMAND or SPOT; lists cannot contain empty strings"
   }
 }
 

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -220,12 +220,11 @@ variable "custom_node_groups" {
   validation {
     condition = alltrue([
       for ng in var.custom_node_groups : (
-        # (
-        #   try(length(trim(ng.instance_type)), 0) > 0 ||
-        #   length(ng.instance_type_list) > 0
-        # )
-        # &&
-        contains(["ON_DEMAND","SPOT"], try(ng.capacity_type, "ON_DEMAND"))
+        (
+          (ng.instance_type != null && ng.instance_type != "") ||
+          length(ng.instance_type_list) > 0
+        )
+        && contains(["ON_DEMAND","SPOT"], try(ng.capacity_type, "ON_DEMAND"))
         && alltrue([for t in ng.instance_type_list : length(trim(t)) > 0])
         && (length(ng.instance_type_list) == 0 || try(ng.instance_type, null) == null)
       )

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -215,20 +215,6 @@ variable "custom_node_groups" {
     labels = map(string)
   }))
   default = []
-  validation {
-    condition = alltrue([
-      for ng in var.custom_node_groups : (
-        (
-          try(length(trim(ng.instance_type)), 0) > 0 ||
-          length(ng.instance_type_list) > 0
-        )
-        && contains(["ON_DEMAND","SPOT"], try(ng.capacity_type, "ON_DEMAND"))
-        && alltrue([for t in ng.instance_type_list : length(trim(t)) > 0])
-        && (length(ng.instance_type_list) == 0 || try(ng.instance_type, null) == null)
-      )
-    ])
-    error_message = "Each custom_node_groups element must set either non-empty instance_type or instance_type_list; capacity_type must be ON_DEMAND or SPOT; lists cannot contain empty strings; if a list is set, instance_type must be unset."
-  }
 }
 
 ###############

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -33,8 +33,8 @@ variable "eks_cluster_version" {
 
 variable "lin_instance_type" {
   description = "Instance size for EKS linux worker nodes."
-  default     = "m5.large"
-  type        = string
+  default     = ["m5.large"]
+  type        = list(string)
 }
 
 # eks autoscaling
@@ -90,8 +90,8 @@ variable "win_max_size" {
 
 variable "win_instance_type" {
   description = "Instance size for EKS linux worker nodes."
-  default     = "m5.large"
-  type        = string
+  default     = ["m5.large"]
+  type        = list(string)
 }
 
 variable "win_capacity_type" {
@@ -176,8 +176,8 @@ variable "custom_node_groups" {
     windows_ami_type         = optional(string, null)
     lin_ami_type             = optional(string, null)
     subnet_ids               = optional(list(string), [])
-    instance_type            = string
-    capacity_type            = string
+    instance_type            = list(string)
+    capacity_type            = optional(string, "ON_DEMAND")
     desired_size             = number
     max_size                 = number
     min_size                 = number

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -72,7 +72,6 @@ variable "lin_capacity_type" {
   description = "Type of capacity associated with the EKS Linux Node Group. Valid values: `ON_DEMAND`, `SPOT`"
   type        = string
   default     = "ON_DEMAND"
-  nullable    = false
   validation {
     condition     = contains(["ON_DEMAND","SPOT"], var.lin_capacity_type)
     error_message = "lin_capacity_type must be one of: ON_DEMAND, SPOT."
@@ -118,7 +117,6 @@ variable "win_capacity_type" {
   description = "Type of capacity associated with the EKS Windows Node Group. Valid values: `ON_DEMAND`, `SPOT`"
   type        = string
   default     = "ON_DEMAND"
-  nullable    = false
   validation {
     condition     = contains(["ON_DEMAND","SPOT"], var.win_capacity_type)
     error_message = "win_capacity_type must be one of: ON_DEMAND, SPOT."

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -220,13 +220,14 @@ variable "custom_node_groups" {
   validation {
     condition = alltrue([
       for ng in var.custom_node_groups : (
-        (
-          try(length(trim(ng.instance_type)), 0) > 0 ||
-          length(ng.instance_type_list) > 0
-        )
-        # && contains(["ON_DEMAND","SPOT"], try(ng.capacity_type, "ON_DEMAND"))
-        # && alltrue([for t in ng.instance_type_list : length(trim(t)) > 0])
-        # && (length(ng.instance_type_list) == 0 || try(ng.instance_type, null) == null)
+        # (
+        #   try(length(trim(ng.instance_type)), 0) > 0 ||
+        #   length(ng.instance_type_list) > 0
+        # )
+        # &&
+        contains(["ON_DEMAND","SPOT"], try(ng.capacity_type, "ON_DEMAND"))
+        && alltrue([for t in ng.instance_type_list : length(trim(t)) > 0])
+        && (length(ng.instance_type_list) == 0 || try(ng.instance_type, null) == null)
       )
     ])
     error_message = "Each custom_node_groups element must set either non-empty instance_type or instance_type_list; capacity_type must be ON_DEMAND or SPOT; lists cannot contain empty strings; if a list is set, instance_type must be unset."

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -62,6 +62,13 @@ variable "lin_ami_type" {
   default     = "AL2023_x86_64_STANDARD"
 }
 
+variable "lin_capacity_type" {
+  description = "Type of capacity associated with the EKS Linux Node Group. Valid values: `ON_DEMAND`, `SPOT`"
+  type        = string
+  default     = "ON_DEMAND"
+  nullable    = false
+}
+
 # # eks autoscaling for windows
 variable "win_min_size" {
   description = "Minimum number of Windows nodes for the EKS"
@@ -87,11 +94,19 @@ variable "win_instance_type" {
   type        = string
 }
 
+variable "win_capacity_type" {
+  description = "Type of capacity associated with the EKS Windows Node Group. Valid values: `ON_DEMAND`, `SPOT`"
+  type        = string
+  default     = "ON_DEMAND"
+  nullable    = false
+}
+
 variable "windows_ami_type" {
   description = "AMI type for the Windows Nodes."
   type        = string
   default     = "WINDOWS_CORE_2019_x86_64"
 }
+
 
 variable "node_host_key_name" {
   description = "Please enter the name of the SSH key pair that should be assigned to the worker nodes of the cluster"
@@ -162,6 +177,7 @@ variable "custom_node_groups" {
     lin_ami_type             = optional(string, null)
     subnet_ids               = optional(list(string), [])
     instance_type            = string
+    capacity_type            = string
     desired_size             = number
     max_size                 = number
     min_size                 = number

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -224,11 +224,12 @@ variable "custom_node_groups" {
           try(length(trim(ng.instance_type)), 0) > 0 ||
           length(ng.instance_type_list) > 0
         )
-        && contains(["ON_DEMAND","SPOT"], try(ng.capacity_type, "ON_DEMAND"))
-        && alltrue([for t in ng.instance_type_list : length(trim(t)) > 0])
+        # && contains(["ON_DEMAND","SPOT"], try(ng.capacity_type, "ON_DEMAND"))
+        # && alltrue([for t in ng.instance_type_list : length(trim(t)) > 0])
+        # && (length(ng.instance_type_list) == 0 || try(ng.instance_type, null) == null)
       )
     ])
-    error_message = "Each custom_node_groups element must set either non-empty instance_type or instance_type_list; capacity_type must be ON_DEMAND or SPOT; lists cannot contain empty strings"
+    error_message = "Each custom_node_groups element must set either non-empty instance_type or instance_type_list; capacity_type must be ON_DEMAND or SPOT; lists cannot contain empty strings; if a list is set, instance_type must be unset."
   }
 }
 

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -35,6 +35,10 @@ variable "lin_instance_type" {
   description = "Instance size for EKS linux worker nodes."
   default     = ["m5.large"]
   type        = list(string)
+  validation {
+    condition     = length(var.lin_instance_type) > 0
+    error_message = "lin_instance_type must contain at least one instance type."
+    }
 }
 
 # eks autoscaling
@@ -67,6 +71,10 @@ variable "lin_capacity_type" {
   type        = string
   default     = "ON_DEMAND"
   nullable    = false
+  validation {
+    condition     = contains(["ON_DEMAND","SPOT"], var.lin_capacity_type)
+    error_message = "lin_capacity_type must be one of: ON_DEMAND, SPOT."
+  }
 }
 
 # # eks autoscaling for windows
@@ -89,9 +97,13 @@ variable "win_max_size" {
 }
 
 variable "win_instance_type" {
-  description = "Instance size for EKS linux worker nodes."
+  description = "Instance size for EKS Windows worker nodes."
   default     = ["m5.large"]
   type        = list(string)
+  validation {
+    condition     = length(var.win_instance_type) > 0
+    error_message = "win_instance_type must contain at least one instance type."
+  }
 }
 
 variable "win_capacity_type" {
@@ -99,6 +111,10 @@ variable "win_capacity_type" {
   type        = string
   default     = "ON_DEMAND"
   nullable    = false
+  validation {
+    condition     = contains(["ON_DEMAND","SPOT"], var.win_capacity_type)
+    error_message = "win_capacity_type must be one of: ON_DEMAND, SPOT."
+  }
 }
 
 variable "windows_ami_type" {
@@ -190,6 +206,15 @@ variable "custom_node_groups" {
     labels = map(string)
   }))
   default = []
+  validation {
+    condition = alltrue([
+      for ng in var.custom_node_groups : (
+        length(ng.instance_type) > 0 &&
+        contains(["ON_DEMAND","SPOT"], try(ng.capacity_type, "ON_DEMAND"))
+      )
+    ])
+    error_message = "Each custom_node_groups element must have at least one instance_type and capacity_type (if set) must be ON_DEMAND or SPOT."
+  }
 }
 
 ###############

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -226,7 +226,6 @@ variable "custom_node_groups" {
         )
         && contains(["ON_DEMAND","SPOT"], try(ng.capacity_type, "ON_DEMAND"))
         && alltrue([for t in ng.instance_type_list : length(trim(t)) > 0])
-        && (length(ng.instance_type_list) == 0 || try(ng.instance_type, null) == null)
       )
     ])
     error_message = "Each custom_node_groups element must set either non-empty instance_type or instance_type_list; capacity_type must be ON_DEMAND or SPOT; lists cannot contain empty strings; if a list is set, instance_type must be unset."

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -55,7 +55,7 @@ variable "lin_desired_size" {
 }
 
 variable "lin_max_size" {
-  description = "Minimum number of Linux nodes for the EKS."
+  description = "Maximum number of Linux nodes for the EKS."
   default     = 2
   type        = number
 }

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -108,6 +108,10 @@ variable "win_instance_type_list" {
   description = "A list of instance types for EKS windows worker nodes. Overrides 'win_instance_type' if specified."
   default     = []
   type        = list(string)
+  validation {
+    condition     = alltrue([for t in var.win_instance_type_list : length(trim(t)) > 0])
+    error_message = "win_instance_type_list cannot contain empty or whitespace-only strings."
+  }
 }
 
 variable "win_capacity_type" {

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -32,13 +32,19 @@ variable "eks_cluster_version" {
 }
 
 variable "lin_instance_type" {
-  description = "Instance size for EKS linux worker nodes."
-  default     = ["m5.large"]
-  type        = list(string)
+  description = "Instance size for EKS linux worker nodes. For multiple instance types, use 'lin_instance_type_list'. This variable is ignored if 'lin_instance_type_list' is provided and not empty."
+  default     = "m5.large"
+  type        = string
   validation {
-    condition     = length(var.lin_instance_type) > 0
+    condition     = length(var.lin_instance_type) != 0
     error_message = "lin_instance_type must contain at least one instance type."
     }
+}
+
+variable "lin_instance_type_list" {
+  description = "A list of instance types for EKS linux worker nodes. If specified, this overrides the 'lin_instance_type' variable."
+  default     = []
+  type        = list(string)
 }
 
 # eks autoscaling
@@ -97,13 +103,19 @@ variable "win_max_size" {
 }
 
 variable "win_instance_type" {
-  description = "Instance size for EKS Windows worker nodes."
-  default     = ["m5.large"]
-  type        = list(string)
-  validation {
-    condition     = length(var.win_instance_type) > 0
+  description = "Instance size for EKS windows worker nodes. For multiple instance types, use 'win_instance_type_list'. This variable is ignored if 'win_instance_type_list' is provided and not empty."
+  default     = "m5.large"
+  type        = string
+   validation {
+    condition     = length(var.win_instance_type) != 0
     error_message = "win_instance_type must contain at least one instance type."
-  }
+    }
+}
+
+variable "win_instance_type_list" {
+  description = "A list of instance types for EKS windows worker nodes. Overrides 'win_instance_type' if specified."
+  default     = []
+  type        = list(string)
 }
 
 variable "win_capacity_type" {
@@ -192,7 +204,8 @@ variable "custom_node_groups" {
     windows_ami_type         = optional(string, null)
     lin_ami_type             = optional(string, null)
     subnet_ids               = optional(list(string), [])
-    instance_type            = list(string)
+    instance_type             = optional(string) # For backward compatibility. Use 'instance_type_list' for multiple types. This is ignored if 'instance_type_list' is set.
+    instance_type_list        = optional(list(string), []) # New list attribute for multiple instance types. Overrides 'instance_type'.
     capacity_type            = optional(string, "ON_DEMAND")
     desired_size             = number
     max_size                 = number
@@ -206,15 +219,6 @@ variable "custom_node_groups" {
     labels = map(string)
   }))
   default = []
-  validation {
-    condition = alltrue([
-      for ng in var.custom_node_groups : (
-        length(ng.instance_type) > 0 &&
-        contains(["ON_DEMAND","SPOT"], try(ng.capacity_type, "ON_DEMAND"))
-      )
-    ])
-    error_message = "Each custom_node_groups element must have at least one instance_type and capacity_type (if set) must be ON_DEMAND or SPOT."
-  }
 }
 
 ###############

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -214,11 +214,16 @@ variable "custom_node_groups" {
   validation {
     condition = alltrue([
       for ng in var.custom_node_groups : (
-        length(ng.instance_type) > 0 || length(ng.instance_type_list) > 0 &&
-        contains(["ON_DEMAND","SPOT"], try(ng.capacity_type, "ON_DEMAND"))
+        (
+          try(length(trim(ng.instance_type)), 0) > 0 ||
+          length(ng.instance_type_list) > 0
+        )
+        && contains(["ON_DEMAND","SPOT"], try(ng.capacity_type, "ON_DEMAND"))
+        && alltrue([for t in ng.instance_type_list : length(trim(t)) > 0])
+        && (length(ng.instance_type_list) == 0 || try(ng.instance_type, null) == null)
       )
     ])
-    error_message = "Each custom_node_groups element must have at least one instance_type and capacity_type (if set) must be ON_DEMAND or SPOT."
+    error_message = "Each custom_node_groups element must set either non-empty instance_type or instance_type_list; capacity_type must be ON_DEMAND or SPOT; lists cannot contain empty strings; if a list is set, instance_type must be unset."
   }
 }
 

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -211,6 +211,15 @@ variable "custom_node_groups" {
     labels = map(string)
   }))
   default = []
+  validation {
+    condition = alltrue([
+      for ng in var.custom_node_groups : (
+        length(ng.instance_type) > 0 || length(ng.instance_type_list) > 0 &&
+        contains(["ON_DEMAND","SPOT"], try(ng.capacity_type, "ON_DEMAND"))
+      )
+    ])
+    error_message = "Each custom_node_groups element must have at least one instance_type and capacity_type (if set) must be ON_DEMAND or SPOT."
+  }
 }
 
 ###############

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -35,10 +35,6 @@ variable "lin_instance_type" {
   description = "Instance size for EKS linux worker nodes. For multiple instance types, use 'lin_instance_type_list'. This variable is ignored if 'lin_instance_type_list' is provided and not empty."
   default     = "m5.large"
   type        = string
-  validation {
-    condition     = length(var.lin_instance_type) != 0
-    error_message = "lin_instance_type must contain at least one instance type."
-    }
 }
 
 variable "lin_instance_type_list" {
@@ -106,10 +102,6 @@ variable "win_instance_type" {
   description = "Instance size for EKS windows worker nodes. For multiple instance types, use 'win_instance_type_list'. This variable is ignored if 'win_instance_type_list' is provided and not empty."
   default     = "m5.large"
   type        = string
-   validation {
-    condition     = length(var.win_instance_type) != 0
-    error_message = "win_instance_type must contain at least one instance type."
-    }
 }
 
 variable "win_instance_type_list" {

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -52,6 +52,7 @@ module "eks" {
         max_size       = var.lin_max_size
         desired_size   = var.lin_desired_size
         key_name       = var.node_host_key_name
+        capacity_type  = var.lin_capacity_type
 
         ebs_optimized = true
         block_device_mappings = [
@@ -79,6 +80,8 @@ module "eks" {
         max_size       = var.win_max_size
         desired_size   = var.win_desired_size
         key_name       = var.node_host_key_name
+        capacity_type  = var.win_capacity_type
+        
         # #   #####################
         # #   #### BOOTSTRAPING ###
         # #   #####################
@@ -130,7 +133,8 @@ module "eks" {
       max_size       = ng.max_size
       desired_size   = ng.desired_size
       key_name       = var.node_host_key_name
-
+      capacity_type  = try(ng.capacity_type, "ON_DEMAND")
+      
       # #   #####################
       # #   #### BOOTSTRAPING ###
       # #   #####################

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -47,7 +47,7 @@ module "eks" {
         }
 
         ami_type       = var.lin_ami_type
-        instance_types = var.lin_instance_type
+        instance_types = local.linux_instance_types
         min_size       = var.lin_min_size
         max_size       = var.lin_max_size
         desired_size   = var.lin_desired_size
@@ -75,7 +75,7 @@ module "eks" {
           "k8s.io/cluster-autoscaler/enabled"                 = "true",
           "k8s.io/cluster-autoscaler/${var.eks_cluster_name}" = "owned"
         }
-        instance_types = var.win_instance_type
+        instance_types = local.windows_instance_types
         min_size       = var.win_min_size
         max_size       = var.win_max_size
         desired_size   = var.win_desired_size
@@ -128,7 +128,7 @@ module "eks" {
         ng.lin_ami_type != null ? ng.lin_ami_type : var.lin_ami_type 
       ) : null
       subnet_ids     = length(ng.subnet_ids) > 0 ? ng.subnet_ids : concat(var.private_subnet_ids, var.public_subnet_ids),
-      instance_types = ng.instance_type
+      instance_types = local.custom_node_group_instance_types[ng.name]
       min_size       = ng.min_size
       max_size       = ng.max_size
       desired_size   = ng.desired_size

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -130,7 +130,7 @@ module "eks" {
       subnet_ids     = length(ng.subnet_ids) > 0 ? ng.subnet_ids : concat(var.private_subnet_ids, var.public_subnet_ids),
       
       # Try instance_type_list first, then instance_type, finally empty list
-      instance_types = length(ng.instance_type_list) > 0 ? ng.instance_type_list : (ng.instance_type != null ? [ng.instance_type] : [])
+      instance_types = length(coalesce(ng.instance_type_list, [])) > 0 ? coalesce(ng.instance_type_list, []) : (ng.instance_type != null ? [ng.instance_type] : [])
       
       min_size       = ng.min_size
       max_size       = ng.max_size

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -128,7 +128,10 @@ module "eks" {
         ng.lin_ami_type != null ? ng.lin_ami_type : var.lin_ami_type 
       ) : null
       subnet_ids     = length(ng.subnet_ids) > 0 ? ng.subnet_ids : concat(var.private_subnet_ids, var.public_subnet_ids),
-      instance_types = local.custom_node_group_instance_types[ng.name]
+      
+      # Try instance_type_list first, then instance_type, finally empty list
+      instance_types = length(ng.instance_type_list) > 0 ? ng.instance_type_list : (ng.instance_type != null ? [ng.instance_type] : [])
+      
       min_size       = ng.min_size
       max_size       = ng.max_size
       desired_size   = ng.desired_size

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -47,7 +47,7 @@ module "eks" {
         }
 
         ami_type       = var.lin_ami_type
-        instance_types = [var.lin_instance_type]
+        instance_types = var.lin_instance_type
         min_size       = var.lin_min_size
         max_size       = var.lin_max_size
         desired_size   = var.lin_desired_size
@@ -75,7 +75,7 @@ module "eks" {
           "k8s.io/cluster-autoscaler/enabled"                 = "true",
           "k8s.io/cluster-autoscaler/${var.eks_cluster_name}" = "owned"
         }
-        instance_types = [var.win_instance_type]
+        instance_types = var.win_instance_type
         min_size       = var.win_min_size
         max_size       = var.win_max_size
         desired_size   = var.win_desired_size
@@ -128,12 +128,12 @@ module "eks" {
         ng.lin_ami_type != null ? ng.lin_ami_type : var.lin_ami_type 
       ) : null
       subnet_ids     = length(ng.subnet_ids) > 0 ? ng.subnet_ids : concat(var.private_subnet_ids, var.public_subnet_ids),
-      instance_types = [ng.instance_type]
+      instance_types = ng.instance_type
       min_size       = ng.min_size
       max_size       = ng.max_size
       desired_size   = ng.desired_size
       key_name       = var.node_host_key_name
-      capacity_type  = try(ng.capacity_type, "ON_DEMAND")
+      capacity_type  = ng.capacity_type
       
       # #   #####################
       # #   #### BOOTSTRAPING ###

--- a/docs/UPGRADE-3.7.0.md
+++ b/docs/UPGRADE-3.7.0.md
@@ -1,0 +1,91 @@
+# Upgrade from v3.6.1 to v3.7.0
+
+## Overview
+
+This upgrade introduces breaking changes to improve instance type availability and flexibility. Starting from version 3.7.0, instance type variables now expect lists of strings instead of single strings to enable support for multiple instance types for better availability.
+
+## List of backwards incompatible changes
+
+- `lin_instance_type`, `win_instance_type`, `instance_type` now expect lists instead of single strings
+
+| Variable | Before (v3.6.1) | After (v3.7.0) | Description |
+|----------|------------------|-----------------|-------------|
+| `lin_instance_type` | `"t3.medium"` | `["t3.medium"]` | Linux node group instance type(s) |
+| `win_instance_type` | `"t3.xlarge"` | `["t3.xlarge"]` | Windows node group instance type(s) |
+| `instance_type` in `custom_node_groups` | `"t3.large"` | `["t3.large"]` | Custom node group instance type(s) |
+
+### Variable and output changes
+
+1. Added variables:
+    - `lin_capacity_type`
+    - `win_capacity_type`
+    - `capacity_type` in `custom_node_groups`
+
+### Migration Examples
+
+#### Before (v3.6.1)
+```hcl
+module "eks-windows" {
+  source = "aws-terraform-module/eks-windows/aws"
+  version = "3.6.1"
+  
+  lin_instance_type = "m5.2xlarge"
+  win_instance_type = "t3.xlarge"
+  
+  custom_node_groups = [
+    {
+      name         = "windows-group"
+      platform     = "windows"
+      instance_type = "t3.large"
+      # ... other configuration
+    }
+  ]
+}
+```
+
+#### After (v3.7.0)
+```hcl
+module "eks-windows" {
+  source = "aws-terraform-module/eks-windows/aws"
+  version = "3.7.0"
+  
+  lin_instance_type = ["m5.2xlarge"]
+  win_instance_type = ["t3.xlarge"]
+  
+  # New capacity type variables for v3.7.0
+  lin_capacity_type = "ON_DEMAND"  # or "SPOT"
+  win_capacity_type = "ON_DEMAND"  # or "SPOT"
+  
+  custom_node_groups = [
+    {
+      name         = "windows-group"
+      platform     = "windows"
+      instance_type = ["t3.large"]
+      capacity_type = "ON_DEMAND"  # or "SPOT"
+      # ... other configuration
+    }
+  ]
+}
+```
+
+## New Features
+
+### Multiple Instance Types Support
+
+With this change, you can now specify multiple instance types for better availability:
+
+```hcl
+# Multiple instance types for main node groups
+lin_instance_type = ["m5.large", "m5.xlarge", "m6i.large"]
+win_instance_type = ["t3.xlarge", "t3.2xlarge"]
+
+# Multiple instance types in custom node groups
+custom_node_groups = [
+  {
+    name         = "linux-mixed"
+    platform     = "linux"
+    instance_type = ["m5.large", "m5.xlarge", "m6i.large"]
+    capacity_type = "SPOT"  # Use spot instances for cost optimization
+    # ... other configuration
+  }
+]

--- a/docs/UPGRADE-3.7.0.md
+++ b/docs/UPGRADE-3.7.0.md
@@ -4,69 +4,17 @@
 
 This upgrade introduces breaking changes to improve instance type availability and flexibility. Starting from version 3.7.0, instance type variables now expect lists of strings instead of single strings to enable support for multiple instance types for better availability.
 
-## List of backwards incompatible changes
-
-- `lin_instance_type`, `win_instance_type`, `instance_type` now expect lists instead of single strings
-
-| Variable | Before (v3.6.1) | After (v3.7.0) | Description |
-|----------|------------------|-----------------|-------------|
-| `lin_instance_type` | `"t3.medium"` | `["t3.medium"]` | Linux node group instance type(s) |
-| `win_instance_type` | `"t3.xlarge"` | `["t3.xlarge"]` | Windows node group instance type(s) |
-| `instance_type` in `custom_node_groups` | `"t3.large"` | `["t3.large"]` | Custom node group instance type(s) |
-
-### Variable and output changes
+## Variable and output changes
 
 1. Added variables:
     - `lin_capacity_type`
     - `win_capacity_type`
     - `capacity_type` in `custom_node_groups`
 
-### Migration Examples
+    - `lin_instance_type_list`
+    - `win_instance_type_list`
+    - `instance_type_list` in `custom_node_groups`
 
-#### Before (v3.6.1)
-```hcl
-module "eks-windows" {
-  source = "aws-terraform-module/eks-windows/aws"
-  version = "3.6.1"
-  
-  lin_instance_type = "m5.2xlarge"
-  win_instance_type = "t3.xlarge"
-  
-  custom_node_groups = [
-    {
-      name         = "windows-group"
-      platform     = "windows"
-      instance_type = "t3.large"
-      # ... other configuration
-    }
-  ]
-}
-```
-
-#### After (v3.7.0)
-```hcl
-module "eks-windows" {
-  source = "aws-terraform-module/eks-windows/aws"
-  version = "3.7.0"
-  
-  lin_instance_type = ["m5.2xlarge"]
-  win_instance_type = ["t3.xlarge"]
-  
-  # New capacity type variables for v3.7.0
-  lin_capacity_type = "ON_DEMAND"  # or "SPOT"
-  win_capacity_type = "ON_DEMAND"  # or "SPOT"
-  
-  custom_node_groups = [
-    {
-      name         = "windows-group"
-      platform     = "windows"
-      instance_type = ["t3.large"]
-      capacity_type = "ON_DEMAND"  # or "SPOT"
-      # ... other configuration
-    }
-  ]
-}
-```
 
 ## New Features
 
@@ -76,16 +24,30 @@ With this change, you can now specify multiple instance types for better availab
 
 ```hcl
 # Multiple instance types for main node groups
-lin_instance_type = ["m5.large", "m5.xlarge", "m6i.large"]
-win_instance_type = ["t3.xlarge", "t3.2xlarge"]
+lin_instance_type = "m5.large"
+win_instance_type = "t3.xlarge"
 
+# If you set both variables, *_instance_type_list takes precedence over *_instance_type
+lin_instance_type_list = ["m5.large", "m5.xlarge", "m6i.large"]
+win_instance_type_list = ["t3.xlarge", "t3.2xlarge"]
+
+```
+
+```
 # Multiple instance types in custom node groups
 custom_node_groups = [
   {
     name         = "linux-mixed"
     platform     = "linux"
-    instance_type = ["m5.large", "m5.xlarge", "m6i.large"]
+
+    # Keep instance_type for backward-compatibility, but if both are supplied
+    # instance_type_list is used and instance_type is ignored.
+    instance_type = "m5.large"
+    instance_type_list = ["m5.large", "m5.xlarge", "m6i.large"]
+    
     capacity_type = "SPOT"  # Use spot instances for cost optimization
     # ... other configuration
   }
 ]
+
+```

--- a/docs/UPGRADE-3.7.0.md
+++ b/docs/UPGRADE-3.7.0.md
@@ -2,7 +2,12 @@
 
 ## Overview
 
-This upgrade introduces breaking changes to improve instance type availability and flexibility. Starting from version 3.7.0, instance type variables now expect lists of strings instead of single strings to enable support for multiple instance types for better availability.
+Version 3.7.0 focuses on improving availability by letting each node-group choose from **multiple instance types**.  
+- New `*_instance_type_list` variables accept a list of instance types (e.g. `["m5.large", "m5.xlarge"]`).  
+- Existing `*_instance_type` variables are still supported for backward-compatibility
+- If both variables are set for the same node-group, the module uses `*_instance_type_list` and ignores `*_instance_type`.  
+
+The release also introduces `lin_capacity_type`, `win_capacity_type`, and `capacity_type` inside `custom_node_groups` so you can choose `ON_DEMAND` or `SPOT` capacity per group.
 
 ## Variable and output changes
 


### PR DESCRIPTION
- Add `capacity_type`, valid value are: `ON_DEMAND`; `SPOT`. Default is `ON_DEMAND`
- Update `instance_type` to from **string** to **list(string)**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Support for multiple instance types per node group (list takes precedence), per-group capacity control (ON_DEMAND/SPOT), and option to assign an SSH key to worker nodes; input validation prevents empty instance entries and invalid capacity values.

- **Documentation**
  - README, public docs, examples, and an UPGRADE guide updated with list-based instance-type usage, capacity_type guidance, migration steps, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->