### PR TITLE
add *_instance_market_options

### DIFF
--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -215,6 +215,16 @@ variable "custom_node_groups" {
       effect = string
     }))
     labels = map(string)
+    instance_market_options = optional(object({
+      market_type = optional(string)
+      spot_options = optional(object({
+        block_duration_minutes         = optional(number)
+        instance_interruption_behavior = optional(string)
+        max_price                      = optional(string)
+        spot_instance_type             = optional(string)
+        valid_until                    = optional(string)
+      }))
+    }))
   }))
   default = []
   validation {
@@ -259,4 +269,38 @@ variable "coredns_addon_version" {
   type        = string
   default     = null
 
+}
+
+
+###########################
+## Spot Instance Options ##
+###########################
+variable "lin_instance_market_options" {
+  description = "The market (purchasing) option for the instance"
+  type = object({
+    market_type = optional(string)
+    spot_options = optional(object({
+      block_duration_minutes         = optional(number)
+      instance_interruption_behavior = optional(string)
+      max_price                      = optional(string)
+      spot_instance_type             = optional(string)
+      valid_until                    = optional(string)
+    }))
+  })
+  default = null
+}
+
+variable "win_instance_market_options" {
+  description = "The market (purchasing) option for the instance"
+  type = object({
+    market_type = optional(string)
+    spot_options = optional(object({
+      block_duration_minutes         = optional(number)
+      instance_interruption_behavior = optional(string)
+      max_price                      = optional(string)
+      spot_instance_type             = optional(string)
+      valid_until                    = optional(string)
+    }))
+  })
+  default = null
 }

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -276,7 +276,7 @@ variable "coredns_addon_version" {
 ## Spot Instance Options ##
 ###########################
 variable "lin_instance_market_options" {
-  description = "The market (purchasing) option for the instance"
+  description = "The market (purchasing) option for linux instances"
   type = object({
     market_type = optional(string)
     spot_options = optional(object({
@@ -291,7 +291,7 @@ variable "lin_instance_market_options" {
 }
 
 variable "win_instance_market_options" {
-  description = "The market (purchasing) option for the instance"
+  description = "The market (purchasing) option for windows instances"
   type = object({
     market_type = optional(string)
     spot_options = optional(object({

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -53,6 +53,7 @@ module "eks" {
         desired_size   = var.lin_desired_size
         key_name       = var.node_host_key_name
         capacity_type  = var.lin_capacity_type
+        instance_market_options = var.lin_instance_market_options
 
         ebs_optimized = true
         block_device_mappings = [
@@ -81,7 +82,8 @@ module "eks" {
         desired_size   = var.win_desired_size
         key_name       = var.node_host_key_name
         capacity_type  = var.win_capacity_type
-        
+        instance_market_options = var.win_instance_market_options
+
         # #   #####################
         # #   #### BOOTSTRAPING ###
         # #   #####################

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -139,6 +139,7 @@ module "eks" {
       desired_size   = ng.desired_size
       key_name       = var.node_host_key_name
       capacity_type  = ng.capacity_type
+      # instance_market_options = ng.instance_market_options
       
       # #   #####################
       # #   #### BOOTSTRAPING ###


### PR DESCRIPTION
- add `*_instance_market_options` to adjust Spot `max_price` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable instance market options for Linux and Windows managed node groups, including Spot parameters (max price, interruption behavior, duration, type, expiry).
  * Enabled optional per-node-group market configuration for custom node groups, allowing granular Spot vs On‑Demand control while preserving existing validations and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->