### PR TITLE
Update c1-version.tf

### DIFF
--- a/c1-version.tf
+++ b/c1-version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.0"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened Terraform AWS provider version to ~> 6.0, restricting upgrades to the 6.x line for improved stability and predictable builds.
  * Reduces risk from accidental major-version updates while keeping access to compatible minor/patch releases.
  * No functional changes expected; existing workflows and deployments should continue to operate normally. If you pin different versions locally, align to 6.x to avoid plan/apply errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->