### PR TITLE
[Enhancement] Disabling self-managed addon bootstrap

### DIFF
--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -99,6 +99,11 @@ variable "disable_windows_defender" {
   default     = false # Set the default as per your requirement
 }
 
+variable "bootstrap_self_managed_addons" {
+  type    = bool
+  default = false
+}
+
 ######################
 ## EXTRA NODE GROUP ##
 # ######################

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -38,6 +38,8 @@ module "eks" {
   # which will allow resources to be deployed into the cluster
   enable_cluster_creator_admin_permissions = true
 
+  bootstrap_self_managed_addons = false
+
   eks_managed_node_groups = merge(
     {
       linux = {

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -38,7 +38,7 @@ module "eks" {
   # which will allow resources to be deployed into the cluster
   enable_cluster_creator_admin_permissions = true
 
-  bootstrap_self_managed_addons = false
+  bootstrap_self_managed_addons = var.bootstrap_self_managed_addons
 
   eks_managed_node_groups = merge(
     {


### PR DESCRIPTION
## Context
While maintaining clusters pinned to `3.5.0`, `terraform plan` showed a **cluster replacement** triggered by addon bootstrapping. The module attempted to (re)bootstrap self-managed EKS addons that we manage externally, which would cause unnecessary and risky control-plane replacement.

## Changes
- Add and set `bootstrap_self_managed_addons = false` to prevent (re)bootstrapping self-managed addons on existing clusters.

```hcl
module "eks-windows" {
  # ...existing config...
  bootstrap_self_managed_addons = false
}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to control bootstrapping of self-managed EKS add-ons during cluster provisioning (default: off). No changes to existing behavior unless explicitly enabled.

* **Chores**
  * Propagated the new setting into the EKS module configuration for consistency across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->