### PR TITLE
Update README & Rename changelog doc after update Taint

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ module "eks-windows" {
         max_size     = 3
         desired_size = 2
         disable_windows_defender = true
-        # For version 3.x.x and earlier (deprecated in 4.x)
+        # For version 3.7.x and earlier (deprecated in 4.x)
         taints = [
           {
             key    = "os"

--- a/README.md
+++ b/README.md
@@ -208,23 +208,14 @@ module "eks-windows" {
         max_size     = 3
         desired_size = 2
         disable_windows_defender = true
-        # For version 3.7.x and earlier (deprecated in 4.x)
-        taints = [
-          {
+        
+        taints = {
+          os = {
             key    = "os"
-            value  = "windows"
+            value  = "windows"  # Optional in 4.x
             effect = "NO_SCHEDULE"
           }
-        ]
-        
-        # For version 4.x and onward (new format)
-        # taints = {
-        #   os = {
-        #     key    = "os"
-        #     value  = "windows"  # Optional in 4.x
-        #     effect = "NO_SCHEDULE"
-        #   }
-        # }
+        }
         labels = {
           "os" = "windows"
         }
@@ -241,9 +232,8 @@ module "eks-windows" {
     #     min_size     = 1
     #     max_size     = 3
     #     desired_size = 2
-    #     taints      = []  # v3.x.x format
-    #     # taints    = {}  # v4.x format
-    #     labels      = {}
+    #     taints       = {} 
+    #     labels       = {}
     #   }
     # ]
 
@@ -268,8 +258,7 @@ the details of the custom\_node\_groups variable
 | `max_size` | `number` | The maximum number of nodes in the node group. |
 | `min_size` | `number` | The minimum number of nodes in the node group. |
 | `disable_windows_defender` | `bool` | (Optional, Default = `false`) Whether to disable Windows Defender on the nodes in the node group. |
-| `taints` | `list(object({key = string, value = string, effect = string}))` | **v3.7.x and earlier**: A list of taints to apply to the nodes in the node group. Each taint is an object with `key`, `value` (required), and `effect` attributes. |
-| `taints` | `map(object({key = string, value = optional(string), effect = string}))` | **v4.x and onward**: A map of taints to apply to the nodes in the node group. Each taint is an object with `key`, `value` (optional), and `effect` attributes. |
+| `taints` | `map(object({key = string, value = optional(string), effect = string}))` | A map of taints to apply to the nodes in the node group. Each taint is an object with `key`, `value` (optional), and `effect` attributes. |
 | `labels` | `map(string)` | A map of labels to apply to the nodes in the node group. Each label is a key-value pair. |
 | `windows_ami_type` | `string` | Specify the Windows version, for your EKS Windows node group (Default = `WINDOWS_CORE_2019_x86_64`) |
 | `lin_ami_type` | `string` | Specify the Linux AMI type for your EKS Linux node group (Default = `AL2023_x86_64_STANDARD`) |

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ module "eks-windows" {
         max_size     = 3
         desired_size = 2
         disable_windows_defender = true
+        # For version 3.x.x and earlier (deprecated in 4.x)
         taints = [
           {
             key    = "os"
@@ -215,6 +216,15 @@ module "eks-windows" {
             effect = "NO_SCHEDULE"
           }
         ]
+        
+        # For version 4.x and onward (new format)
+        # taints = {
+        #   os = {
+        #     key    = "os"
+        #     value  = "windows"  # Optional in 4.x
+        #     effect = "NO_SCHEDULE"
+        #   }
+        # }
         labels = {
           "os" = "windows"
         }
@@ -231,7 +241,8 @@ module "eks-windows" {
     #     min_size     = 1
     #     max_size     = 3
     #     desired_size = 2
-    #     taints      = []
+    #     taints      = []  # v3.x.x format
+    #     # taints    = {}  # v4.x format
     #     labels      = {}
     #   }
     # ]
@@ -257,7 +268,8 @@ the details of the custom\_node\_groups variable
 | `max_size` | `number` | The maximum number of nodes in the node group. |
 | `min_size` | `number` | The minimum number of nodes in the node group. |
 | `disable_windows_defender` | `bool` | (Optional, Default = `false`) Whether to disable Windows Defender on the nodes in the node group. |
-| `taints` | `list(object({key = string, value = string, effect = string}))` | A list of taints to apply to the nodes in the node group. Each taint is an object with `key`, `value`, and `effect` attributes. |
+| `taints` | `list(object({key = string, value = string, effect = string}))` | **v3.7.x and earlier**: A list of taints to apply to the nodes in the node group. Each taint is an object with `key`, `value` (required), and `effect` attributes. |
+| `taints` | `map(object({key = string, value = optional(string), effect = string}))` | **v4.x and onward**: A map of taints to apply to the nodes in the node group. Each taint is an object with `key`, `value` (optional), and `effect` attributes. |
 | `labels` | `map(string)` | A map of labels to apply to the nodes in the node group. Each label is a key-value pair. |
 | `windows_ami_type` | `string` | Specify the Windows version, for your EKS Windows node group (Default = `WINDOWS_CORE_2019_x86_64`) |
 | `lin_ami_type` | `string` | Specify the Linux AMI type for your EKS Linux node group (Default = `AL2023_x86_64_STANDARD`) |
@@ -266,6 +278,7 @@ the details of the custom\_node\_groups variable
 
 *   [Upgrade to 3.x.x](https://github.com/aws-terraform-module/terraform-aws-eks-windows/blob/master/docs/UPGRADE-3.0.md)
 *   [Upgrade from 3.x.x to 3.7.x](https://github.com/aws-terraform-module/terraform-aws-eks-windows/blob/master/docs/UPGRADE-3.7.0.md)
+*   [Upgrade from 3.7.x to 4.0](https://github.com/aws-terraform-module/terraform-aws-eks-windows/blob/master/docs/UPGRADE-4.0.0.md)
 
 ## Issue Reference:
 

--- a/docs/UPGRADE-4.0.0.md
+++ b/docs/UPGRADE-4.0.0.md
@@ -57,12 +57,12 @@ custom_node_groups = [
 ```
 
 ### Migration Steps
+> Prerequisite: Terraform CLI v1.3 or newer (required for `optional(...)` object attributes and optional attribute defaults).
 
 1. **Change structure**: Convert `taints = [...]` to `taints = {...}`
 2. **Add map keys**: Wrap each taint object in a map with a unique key (typically the same as the `key` field)
 3. **Remove empty values**: Remove `value` fields that are empty or null (they're now optional)
 4. **Ensure uniqueness**: Make sure each taint has a unique map key
-W
 
 ## Example Migration
 

--- a/docs/UPGRADE-4.0.md
+++ b/docs/UPGRADE-4.0.md
@@ -1,4 +1,4 @@
-# Upgrade from v3.7.x to v4.0.0
+# Upgrade from v3.7.x to v4.x
 
 ## Overview
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated README to document dual-format taints for custom_node_groups: list format (v3.x, value required) and map format (v4.x+, value optional).
  - Expanded details table and added examples for both formats, showing taints = [] (v3.x) and taints = {} (v4.x+).
  - Added an upgrade note for moving from 3.7.x to 4.x in The Changes.
  - Revised upgrade guide to target v4.x, added Migration Steps, noted Terraform CLI v1.3+ requirement, and cleaned minor formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->