### PR TITLE
Feature enable control plane logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,14 +260,15 @@ the details of the custom\_node\_groups variable
 | `disable_windows_defender` | `bool` | (Optional, Default = `false`) Whether to disable Windows Defender on the nodes in the node group. |
 | `taints` | `map(object({key = string, value = optional(string), effect = string}))` | A map of taints to apply to the nodes in the node group. Each taint is an object with `key`, `value` (optional), and `effect` attributes. |
 | `labels` | `map(string)` | A map of labels to apply to the nodes in the node group. Each label is a key-value pair. |
-| `windows_ami_type` | `string` | Specify the Windows version, for your EKS Windows node group (Default = `WINDOWS_CORE_2019_x86_64`) |
+| `windows_ami_type` | `string` | Specify the Windows version, for your EKS Windows node group (Default = `WINDOWS_CORE_2022_x86_64`) |
 | `lin_ami_type` | `string` | Specify the Linux AMI type for your EKS Linux node group (Default = `AL2023_x86_64_STANDARD`) |
 
 ## The Changes:
 
 *   [Upgrade to 3.x.x](https://github.com/aws-terraform-module/terraform-aws-eks-windows/blob/master/docs/UPGRADE-3.0.md)
 *   [Upgrade from 3.x.x to 3.7.x](https://github.com/aws-terraform-module/terraform-aws-eks-windows/blob/master/docs/UPGRADE-3.7.0.md)
-*   [Upgrade from 3.7.x to 4.0](https://github.com/aws-terraform-module/terraform-aws-eks-windows/blob/master/docs/UPGRADE-4.0.0.md)
+*   [Upgrade from 3.7.x to 4.0](https://github.com/aws-terraform-module/terraform-aws-eks-windows/blob/master/docs/UPGRADE-4.0.md)
+*   [Upgrade from 4.0.x to 4.1.0](https://github.com/aws-terraform-module/terraform-aws-eks-windows/blob/master/docs/UPGRADE-4.1.md)
 
 ## Issue Reference:
 

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -130,7 +130,7 @@ variable "win_capacity_type" {
 variable "windows_ami_type" {
   description = "AMI type for the Windows Nodes."
   type        = string
-  default     = "WINDOWS_CORE_2019_x86_64"
+  default     = "WINDOWS_CORE_2022_x86_64"
 }
 
 

--- a/c3-01-eks-variable.tf
+++ b/c3-01-eks-variable.tf
@@ -225,3 +225,18 @@ variable "control_plane_logs" {
   default = false
 }
 
+variable "create_new" {
+  description = <<EOT
+Set to 'true' for the initial deployment of resources. Set to 'false' when you are upgrading or only changing existing configurations.
+
+For EKS, the VPC CNI and kube-proxy add-ons will be applied with 'before_compute = true', meaning these essential networking components are provisioned before any node groups (compute resources) are created. This ensures the network is fully available and ready for compute workloads when the nodes start.
+
+- VPC-CNI (Amazon's networking plugin): Manages pod networking and allows pods to have native VPC IPs.
+- kube-proxy: Manages Kubernetes networking rules for pod-to-pod and pod-to-service communication.
+
+'before_compute = true' guarantees both add-ons are installed ahead of worker node provisioning so networking is stable and functional for all subsequent workloads.
+EOT
+  type        = bool
+  default     = true
+}
+

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -171,26 +171,26 @@ module "eks" {
     }
   )
 
-  addons = {
-    kube-proxy = {
-      most_recent = true
-    }
-    vpc-cni = {
-      most_recent = true
-    }
-    coredns = {
-      addon_version               = try(var.coredns_addon_version, null)
-      most_recent                 = true //module will fallback to most_recent if addon_version is not provided
-      resolve_conflicts_on_update = "PRESERVE"
-      configuration_values = jsonencode({
-        autoScaling = {
-          enabled     = var.enabled_coredns_auto_scaling
-          minReplicas = var.coredns_min_replicas
-          maxReplicas = var.coredns_max_replicas
-        }
-      })
-    }
-  }
+  # addons = {
+  #   kube-proxy = {
+  #     most_recent = true
+  #   }
+  #   vpc-cni = {
+  #     most_recent = true
+  #   }
+  #   coredns = {
+  #     addon_version               = try(var.coredns_addon_version, null)
+  #     most_recent                 = true //module will fallback to most_recent if addon_version is not provided
+  #     resolve_conflicts_on_update = "PRESERVE"
+  #     configuration_values = jsonencode({
+  #       autoScaling = {
+  #         enabled     = var.enabled_coredns_auto_scaling
+  #         minReplicas = var.coredns_min_replicas
+  #         maxReplicas = var.coredns_max_replicas
+  #       }
+  #     })
+  #   }
+  # }
 
   enabled_log_types = var.control_plane_logs ? [
     "api",

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -38,9 +38,6 @@ module "eks" {
   # which will allow resources to be deployed into the cluster
   enable_cluster_creator_admin_permissions = true
 
-  # Create just the IAM resources for EKS Auto Mode for use with custom node pools
-  create_auto_mode_iam_resources = true
-
   eks_managed_node_groups = merge(
     {
       linux = {
@@ -177,11 +174,11 @@ module "eks" {
   addons = {
     kube-proxy = {
       most_recent = true
-      before_compute = true
+      before_compute = var.create_new
     }
     vpc-cni = {
       most_recent = true
-      before_compute = true
+      before_compute = var.create_new
     }
     coredns = {
       addon_version               = try(var.coredns_addon_version, null)

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -171,26 +171,31 @@ module "eks" {
     }
   )
 
-  # addons = {
-  #   kube-proxy = {
-  #     most_recent = true
-  #   }
-  #   vpc-cni = {
-  #     most_recent = true
-  #   }
-  #   coredns = {
-  #     addon_version               = try(var.coredns_addon_version, null)
-  #     most_recent                 = true //module will fallback to most_recent if addon_version is not provided
-  #     resolve_conflicts_on_update = "PRESERVE"
-  #     configuration_values = jsonencode({
-  #       autoScaling = {
-  #         enabled     = var.enabled_coredns_auto_scaling
-  #         minReplicas = var.coredns_min_replicas
-  #         maxReplicas = var.coredns_max_replicas
-  #       }
-  #     })
-  #   }
-  # }
+  addons = {
+    kube-proxy = {
+      most_recent = true
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "OVERWRITE"
+    }
+    vpc-cni = {
+      most_recent = true
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "OVERWRITE"
+    }
+    coredns = {
+      addon_version               = try(var.coredns_addon_version, null)
+      most_recent                 = true //module will fallback to most_recent if addon_version is not provided
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "OVERWRITE"
+      configuration_values = jsonencode({
+        autoScaling = {
+          enabled     = var.enabled_coredns_auto_scaling
+          minReplicas = var.coredns_min_replicas
+          maxReplicas = var.coredns_max_replicas
+        }
+      })
+    }
+  }
 
   enabled_log_types = var.control_plane_logs ? [
     "api",

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -183,8 +183,7 @@ module "eks" {
     coredns = {
       addon_version               = try(var.coredns_addon_version, null)
       most_recent                 = true //module will fallback to most_recent if addon_version is not provided
-      resolve_conflicts_on_create = "OVERWRITE"
-      resolve_conflicts_on_update = "OVERWRITE"
+      resolve_conflicts_on_update = "PRESERVE"
       configuration_values = jsonencode({
         autoScaling = {
           enabled     = var.enabled_coredns_auto_scaling

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -174,31 +174,29 @@ module "eks" {
     }
   )
 
-  # addons = {
-  #   kube-proxy = {
-  #     most_recent = true
-  #     resolve_conflicts_on_create = "OVERWRITE"
-  #     resolve_conflicts_on_update = "OVERWRITE"
-  #   }
-  #   vpc-cni = {
-  #     most_recent = true
-  #     resolve_conflicts_on_create = "OVERWRITE"
-  #     resolve_conflicts_on_update = "OVERWRITE"
-  #   }
-  #   coredns = {
-  #     addon_version               = try(var.coredns_addon_version, null)
-  #     most_recent                 = true //module will fallback to most_recent if addon_version is not provided
-  #     resolve_conflicts_on_create = "OVERWRITE"
-  #     resolve_conflicts_on_update = "OVERWRITE"
-  #     configuration_values = jsonencode({
-  #       autoScaling = {
-  #         enabled     = var.enabled_coredns_auto_scaling
-  #         minReplicas = var.coredns_min_replicas
-  #         maxReplicas = var.coredns_max_replicas
-  #       }
-  #     })
-  #   }
-  # }
+  addons = {
+    kube-proxy = {
+      most_recent = true
+      before_compute = true
+    }
+    vpc-cni = {
+      most_recent = true
+      before_compute = true
+    }
+    coredns = {
+      addon_version               = try(var.coredns_addon_version, null)
+      most_recent                 = true //module will fallback to most_recent if addon_version is not provided
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "OVERWRITE"
+      configuration_values = jsonencode({
+        autoScaling = {
+          enabled     = var.enabled_coredns_auto_scaling
+          minReplicas = var.coredns_min_replicas
+          maxReplicas = var.coredns_max_replicas
+        }
+      })
+    }
+  }
 
   enabled_log_types = var.control_plane_logs ? [
     "api",

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -38,6 +38,9 @@ module "eks" {
   # which will allow resources to be deployed into the cluster
   enable_cluster_creator_admin_permissions = true
 
+  # Create just the IAM resources for EKS Auto Mode for use with custom node pools
+  create_auto_mode_iam_resources = true
+
   eks_managed_node_groups = merge(
     {
       linux = {
@@ -171,31 +174,31 @@ module "eks" {
     }
   )
 
-  addons = {
-    kube-proxy = {
-      most_recent = true
-      resolve_conflicts_on_create = "OVERWRITE"
-      resolve_conflicts_on_update = "OVERWRITE"
-    }
-    vpc-cni = {
-      most_recent = true
-      resolve_conflicts_on_create = "OVERWRITE"
-      resolve_conflicts_on_update = "OVERWRITE"
-    }
-    coredns = {
-      addon_version               = try(var.coredns_addon_version, null)
-      most_recent                 = true //module will fallback to most_recent if addon_version is not provided
-      resolve_conflicts_on_create = "OVERWRITE"
-      resolve_conflicts_on_update = "OVERWRITE"
-      configuration_values = jsonencode({
-        autoScaling = {
-          enabled     = var.enabled_coredns_auto_scaling
-          minReplicas = var.coredns_min_replicas
-          maxReplicas = var.coredns_max_replicas
-        }
-      })
-    }
-  }
+  # addons = {
+  #   kube-proxy = {
+  #     most_recent = true
+  #     resolve_conflicts_on_create = "OVERWRITE"
+  #     resolve_conflicts_on_update = "OVERWRITE"
+  #   }
+  #   vpc-cni = {
+  #     most_recent = true
+  #     resolve_conflicts_on_create = "OVERWRITE"
+  #     resolve_conflicts_on_update = "OVERWRITE"
+  #   }
+  #   coredns = {
+  #     addon_version               = try(var.coredns_addon_version, null)
+  #     most_recent                 = true //module will fallback to most_recent if addon_version is not provided
+  #     resolve_conflicts_on_create = "OVERWRITE"
+  #     resolve_conflicts_on_update = "OVERWRITE"
+  #     configuration_values = jsonencode({
+  #       autoScaling = {
+  #         enabled     = var.enabled_coredns_auto_scaling
+  #         minReplicas = var.coredns_min_replicas
+  #         maxReplicas = var.coredns_max_replicas
+  #       }
+  #     })
+  #   }
+  # }
 
   enabled_log_types = var.control_plane_logs ? [
     "api",

--- a/c3-02-eks.tf
+++ b/c3-02-eks.tf
@@ -16,7 +16,7 @@ data "aws_subnet" "subnets" {
 
 module "eks" {
   source                         = "terraform-aws-modules/eks/aws"
-  version                        = "21.3.1"
+  version                        = "21.2.0"
   name                           = var.eks_cluster_name
   kubernetes_version             = var.eks_cluster_version
   subnet_ids                     = concat(var.private_subnet_ids, var.public_subnet_ids)

--- a/docs/UPGRADE-4.1.md
+++ b/docs/UPGRADE-4.1.md
@@ -1,0 +1,83 @@
+# Upgrade from v4.0.x to v4.1.x
+
+## Overview
+
+Version 4.1 introduces improvements to control-plane logging, add-on ordering for first-time installs, CoreDNS update safety, and updates the default Windows AMI type.
+
+No breaking variable renames were made; review the behavior changes and adopt the recommended migration steps below.
+
+## Changes
+
+### New: control plane logs toggle
+
+- Added input `control_plane_logs` (bool, default: `false`).
+- When set to `true`, the module enables control-plane logging by mapping to `enabled_log_types` in the upstream EKS module with:
+  - `api`, `audit`, `authenticator`, `controllerManager`, `scheduler`.
+
+Example:
+```hcl
+module "eks-windows" {
+  # ...existing inputs
+  control_plane_logs = true
+}
+```
+
+### New: initial deployment ordering
+
+- Added input `create_new` (bool, default: `true`).
+- For first-time deployments, this ensures the VPC CNI and kube-proxy add-ons are applied before compute (`before_compute = true`).
+- For upgrades or subsequent changes, you can set `create_new = false` to avoid plan diffs related to ordering.
+
+Example:
+```hcl
+module "eks-windows" {
+  # ...existing inputs
+  create_new = true # first-time install; set false for upgrades
+}
+```
+
+### Safer CoreDNS updates
+
+- CoreDNS add-on now preserves cluster-side changes by default:
+  - `resolve_conflicts_on_update = "PRESERVE"`.
+- You can optionally pin a version via `coredns_addon_version` and control autoscaling via:
+  - `enabled_coredns_auto_scaling` (default: `true`)
+  - `coredns_min_replicas` (default: `2`)
+  - `coredns_max_replicas` (default: `20`)
+
+### Default Windows AMI type updated
+
+- `windows_ami_type` default changed to `WINDOWS_CORE_2022_x86_64`.
+
+## Migration steps
+
+1. Review cluster version and region support for Windows Server 2022 AMIs. If you need the previous default, set:
+   ```hcl
+   windows_ami_type = "WINDOWS_CORE_2019_x86_64"
+   ```
+2. For first-time installs, keep `create_new = true` (default). For existing clusters or upgrades, set:
+   ```hcl
+   create_new = false
+   ```
+   to minimize plan noise while preserving behavior.
+3. Enable control-plane logs as needed:
+   ```hcl
+   control_plane_logs = true
+   ```
+4. If CoreDNS has cluster-specific ConfigMap customizations, no action is required; updates now default to `PRESERVE`. If you explicitly need to overwrite, adjust in code to `OVERWRITE` before applying (advanced scenario).
+
+## Additional changes
+
+### Variable and output changes
+
+1. Added variables:
+
+    - `create_new`
+    - `control_plane_logs`
+
+## References
+
+- Upstream EKS module changes and log types naming in v21: [Upgrade guide](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-21.0.md)
+- PR implementing these changes in this module: [#121](https://github.com/aws-terraform-module/terraform-aws-eks-windows/pull/121)
+
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Default Windows node AMI updated from Windows Server 2019 Core to Windows Server 2022 Core. Review workload and image compatibility before applying.
  - Added an upgrade guide for v4.1.

- New Features
  - Added a boolean option to control initial-deploy vs upgrade behavior (affects addon provisioning order).
  - Added control-plane logging toggle.

- Bug Fixes / Behavior Changes
  - kube-proxy and VPC CNI addons run before compute on initial deploy so networking is ready.
  - CoreDNS updates default to preserve cluster-side changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->